### PR TITLE
feat: add interface for featured categories

### DIFF
--- a/src/app/pages/home/home.component.ts
+++ b/src/app/pages/home/home.component.ts
@@ -4,7 +4,7 @@ import { NgFor, NgStyle } from '@angular/common';
 import { RouterLink } from '@angular/router';
 import { GameCardComponent } from '../../components/game-card/game-card.component';
 import { ScrollRevealDirective } from '../../directives/scroll-reveal.directive';
-import { SteamService, SteamApp } from '../../services/steam.service';
+import { SteamService, SteamApp, FeaturedCategoriesResponse } from '../../services/steam.service';
 
 @Component({
   selector: 'app-home',
@@ -27,7 +27,7 @@ export class HomeComponent implements OnInit {
 
   private loadFeatured(): void {
     this.steam.getFeaturedCategories().subscribe({
-      next: (data: any) => {
+      next: (data: FeaturedCategoriesResponse) => {
         // Try to get games from different featured categories
         const categories = ['top_sellers', 'specials', 'popular_new_releases', 'coming_soon', 'new_releases'];
         let games: SteamApp[] = [];

--- a/src/app/services/steam.service.ts
+++ b/src/app/services/steam.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, inject } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 
 export interface SteamApp {
@@ -57,6 +58,19 @@ interface AppListResponse {
   };
 }
 
+interface FeaturedCategory {
+  items: SteamApp[];
+}
+
+export interface FeaturedCategoriesResponse {
+  top_sellers: FeaturedCategory;
+  specials: FeaturedCategory;
+  popular_new_releases: FeaturedCategory;
+  coming_soon: FeaturedCategory;
+  new_releases: FeaturedCategory;
+  [key: string]: FeaturedCategory;
+}
+
 @Injectable({ providedIn: 'root' })
 export class SteamService {
   private readonly http = inject(HttpClient);
@@ -70,8 +84,10 @@ export class SteamService {
     return this.http.get<{ [key: string]: SteamAppDetails }>(`/storeapi/api/appdetails?appids=${appid}&cc=br&l=portuguese`);
   }
 
-  getFeaturedCategories() {
-    return this.http.get('/storeapi/api/featuredcategories?cc=br&l=portuguese');
+  getFeaturedCategories(): Observable<FeaturedCategoriesResponse> {
+    return this.http.get<FeaturedCategoriesResponse>(
+      '/storeapi/api/featuredcategories?cc=br&l=portuguese'
+    );
   }
 
   getNewsForApp(appid: number, count = 5) {


### PR DESCRIPTION
## Summary
- tipa retorno das categorias em destaque com FeaturedCategoriesResponse
- ajusta consumo das categorias em destaque na home

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` (falhou: No binary for ChromeHeadless browser on your platform)
- `npm run build` (falhou: Object is possibly 'undefined' in game-detail component)


------
https://chatgpt.com/codex/tasks/task_e_68ae55ac0e18832791e56f4eedeb4943