### PR TITLE
Remover sinal featured não utilizado

### DIFF
--- a/src/app/pages/home/home.component.ts
+++ b/src/app/pages/home/home.component.ts
@@ -16,16 +16,15 @@ import { SteamService, SteamApp } from '../../services/steam.service';
 export class HomeComponent implements OnInit {
   constructor(private steam: SteamService) {}
 
-  protected readonly featured = signal<SteamApp[]>([]);
   protected readonly news = signal<any[]>([]);
   protected readonly trending = signal<SteamApp[]>([]);
 
   ngOnInit(): void {
-    this.loadFeatured();
+    this.loadTrending();
     this.loadNews();
   }
 
-  private loadFeatured(): void {
+  private loadTrending(): void {
     this.steam.getFeaturedCategories().subscribe({
       next: (data: any) => {
         // Try to get games from different featured categories
@@ -52,8 +51,6 @@ export class HomeComponent implements OnInit {
             { appid: 2345678, name: 'The Witcher 3: Wild Hunt' }
           ];
         }
-        
-        this.featured.set(games);
         this.trending.set(games);
       },
       error: () => {
@@ -68,7 +65,6 @@ export class HomeComponent implements OnInit {
           { appid: 1234567, name: 'Red Dead Redemption 2' },
           { appid: 2345678, name: 'The Witcher 3: Wild Hunt' }
         ];
-        this.featured.set(fallbackGames);
         this.trending.set(fallbackGames);
       }
     });


### PR DESCRIPTION
## Resumo
- remover sinal `featured` e suas atribuições na home
- carregar jogos em destaque diretamente no sinal `trending`

## Testes
- `npm test -- --watch=false --browsers=ChromeHeadless` *(falha: No binary for ChromeHeadless browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68ae55a7f870832798b691ef7d8d9c8b