### PR TITLE
Adiciona rel noopener noreferrer aos links externos

### DIFF
--- a/src/app/pages/game-detail/game-detail.component.html
+++ b/src/app/pages/game-detail/game-detail.component.html
@@ -126,7 +126,7 @@
             <span class="px-4 py-2 bg-yellow-500/20 text-yellow-300 rounded-lg text-lg font-bold border border-yellow-500/30">
               {{ game.metacritic.score }}
             </span>
-            <a [href]="game.metacritic.url" target="_blank" class="text-blue-400 hover:text-blue-300 underline text-sm transition-colors">
+            <a [href]="game.metacritic.url" target="_blank" rel="noopener noreferrer" class="text-blue-400 hover:text-blue-300 underline text-sm transition-colors">
               Ver avaliação
             </a>
           </div>

--- a/src/app/pages/home/home.component.html
+++ b/src/app/pages/home/home.component.html
@@ -84,9 +84,10 @@
               <span class="px-3 py-1 bg-white/10 rounded-full text-xs">{{ item.feedlabel || 'Notícias' }}</span>
             </div>
             
-            <a 
-              [href]="item.url" 
-              target="_blank" 
+            <a
+              [href]="item.url"
+              target="_blank"
+              rel="noopener noreferrer"
               class="inline-flex items-center gap-2 px-6 py-3 bg-gradient-to-r from-yellow-400/20 to-blue-400/20 rounded-xl border border-yellow-400/30 text-sm font-medium text-white group-hover:from-yellow-400/30 group-hover:to-blue-400/30 transition-all duration-300 hover:scale-105"
             >
               <span>Ler mais</span>


### PR DESCRIPTION
## Summary
- adiciona `rel="noopener noreferrer"` em links externos da home
- adiciona `rel="noopener noreferrer"` no link do Metacritic em detalhes do jogo

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(falhou: No binary for ChromeHeadless browser)*

------
https://chatgpt.com/codex/tasks/task_e_68ae55a5d35083279e73c0a8c731ec2b