### PR TITLE
Ajustar teste do App para RouterOutlet

### DIFF
--- a/src/app/app.spec.ts
+++ b/src/app/app.spec.ts
@@ -14,10 +14,10 @@ describe('App', () => {
     expect(app).toBeTruthy();
   });
 
-  it('should render title', () => {
+  it('should render the router outlet', () => {
     const fixture = TestBed.createComponent(App);
     fixture.detectChanges();
     const compiled = fixture.nativeElement as HTMLElement;
-    expect(compiled.querySelector('h1')?.textContent).toContain('Hello, fiel');
+    expect(compiled.querySelector('router-outlet')).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Resumo
- Remove a checagem do título "Hello, fiel" e valida a presença do `RouterOutlet`.

## Testes
- `npm test -- --no-watch --no-progress --browsers=ChromeHeadless` *(falhou: Running as root without --no-sandbox is not supported)*

------
https://chatgpt.com/codex/tasks/task_e_68ae5598f5808327a33a89a5d5fa5bad