### PR TITLE
feat: adicionar serviço de notificação

### DIFF
--- a/src/app/components/tools-panel/tools-panel.component.ts
+++ b/src/app/components/tools-panel/tools-panel.component.ts
@@ -1,5 +1,6 @@
 import { Component, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { NotificationService } from '../../services/notification.service';
 
 interface Tool {
   id: string;
@@ -53,6 +54,8 @@ interface Tool {
   styles: []
 })
 export class ToolsPanelComponent {
+  constructor(private notification: NotificationService) {}
+
   protected readonly tools = signal<Tool[]>([
     {
       id: 'library',
@@ -100,6 +103,6 @@ export class ToolsPanelComponent {
   ]);
 
   private showComingSoon(feature: string): void {
-    alert(`${feature} estará disponível em breve! 🚀`);
+    this.notification.show(`${feature} estará disponível em breve! 🚀`);
   }
 }

--- a/src/app/services/notification.service.spec.ts
+++ b/src/app/services/notification.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+import { NotificationService } from './notification.service';
+
+describe('NotificationService', () => {
+  let service: NotificationService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(NotificationService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});
+

--- a/src/app/services/notification.service.ts
+++ b/src/app/services/notification.service.ts
@@ -1,0 +1,14 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({ providedIn: 'root' })
+export class NotificationService {
+  show(message: string): void {
+    const toast = document.createElement('div');
+    toast.textContent = message;
+    toast.className =
+      'fixed bottom-4 right-4 bg-yellow-400 text-black px-4 py-2 rounded shadow-lg z-50';
+    document.body.appendChild(toast);
+    setTimeout(() => toast.remove(), 3000);
+  }
+}
+


### PR DESCRIPTION
## Resumo
- adicionar NotificationService para exibir toasts estilizados
- utilizar NotificationService no ToolsPanelComponent em vez de alert
- criar teste básico para NotificationService

## Testes
- `npm test` *(falha: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68ae5598788483278c94fee37467d481